### PR TITLE
Fixed spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Discord Tools is a Visual Studio Code extension to code Discord bots more easily
 - `djs.guildmemberadd` : Create a default Discord bot guildMemberAdd event.
 - `djs.guildmemberremove` : Create a default Discord bot guildMemberRemove event.
 - `djs.guildcreate` : Create a default Discord bot guildCreate event.
-- `djs.guilddelete` : Create a default Discord bot guildCreate event.
+- `djs.guilddelete` : Create a default Discord bot guildDelete event.
 - **and 47 other events...**
 
 #### Javascript ([Eris](https://abal.moe/Eris/)) :


### PR DESCRIPTION
Fixed a spelling mistake in readme file on line 63.

djs.guilddelete said "Create a default Discord bot guildCreate event." this was fixed to say "Create a default Discord bot guildDelete event."